### PR TITLE
Add Properties for activation and changed the planet sorting

### DIFF
--- a/DataModels/Activation.cs
+++ b/DataModels/Activation.cs
@@ -35,6 +35,28 @@ public sealed class Activation
     /// </summary>
     public Base Base { get; init; }
 
+		/// <summary>
+		/// Gets the latitude of the activation.
+		/// </summary>
+    public double Longitude { get; init; }
+
+		/// <summary>
+		/// Gets the color percentage of the activation.
+		/// </summary>
+		public double ColorPercentage { get; init; }
+
+		/// <summary>
+		/// Gets the tone percentage of the activation.
+		/// </summary>
+		public double TonePercentage { get; init; }
+
+		/// <summary>
+		/// Gets the base percentage of the activation.
+		/// </summary>
+		public double BasePercentage { get; init; }
+
+		public override String ToString() => $"{Gate.ToNumber()}.{Line.ToNumber()}.{Color.ToNumber()}.{Tone.ToNumber()}.{Base.ToNumber()} C{Math.Round(ColorPercentage)}% T{Math.Round(TonePercentage)}% B{Math.Round(BasePercentage)}%";
+
     /// <summary>
     /// Determines whether the specified <see cref="Activation"/> object is equal to the current object,
     /// considering different levels of comparison depth specified by <see cref="ComparatorDepth"/>.

--- a/Definitions/HumanDesignDefaults.cs
+++ b/Definitions/HumanDesignDefaults.cs
@@ -12,9 +12,18 @@ public static class HumanDesignDefaults
     /// </summary>
     public static readonly Planets[] HumanDesignPlanets =
     [
-        Planets.Sun, Planets.Earth, Planets.Mars, Planets.Mercury,
-        Planets.Venus, Planets.Moon, Planets.Jupiter, Planets.Saturn, 
-        Planets.Uranus, Planets.Neptune, Planets.Pluto, 
-        Planets.NorthNode, Planets.SouthNode
+        Planets.Sun, 
+				Planets.Earth, 
+        Planets.NorthNode, 
+				Planets.SouthNode,
+				Planets.Moon, 
+				Planets.Mercury,
+        Planets.Uranus, 
+        Planets.Venus, 
+				Planets.Mars, 
+				Planets.Neptune, 
+				Planets.Saturn, 
+				Planets.Jupiter, 
+				Planets.Pluto, 
     ];
 }

--- a/Utility/HumanDesignUtility.cs
+++ b/Utility/HumanDesignUtility.cs
@@ -65,10 +65,10 @@ public static class HumanDesignUtility
             Color = (Color)Math.Floor((x % DegreePerLine) / DegreePerColor) + 1,
             Tone = (Tone)Math.Floor((x % DegreePerColor) / DegreePerTone) + 1,
             Base = (Base)Math.Floor((x % DegreePerTone) / DegreePerBase) + 1,
+						ColorPercentage = ((x % DegreePerColor) / DegreePerColor) * 100.0,
+						TonePercentage = ((x % DegreePerTone) / DegreePerTone) * 100.0,
+						BasePercentage = ((x % DegreePerBase) / DegreePerBase) * 100.0,
 						Longitude = longitude,
-						ColorPercentage = (((x % DegreePerLine) % DegreePerColor) / DegreePerColor) * 100.0,
-						TonePercentage = (((x % DegreePerColor) % DegreePerTone) / DegreePerTone) * 100.0,
-						BasePercentage = (((x % DegreePerTone) % DegreePerBase) / DegreePerBase) * 100.0,
         };
     }
     

--- a/Utility/HumanDesignUtility.cs
+++ b/Utility/HumanDesignUtility.cs
@@ -10,7 +10,7 @@ namespace SharpAstrology.Utility;
 public static class HumanDesignUtility
 {
     private const double HdOffsetToZodiac = 3.875;
-    private const double DegreePerGate = 5.626;
+    private const double DegreePerGate = 5.625;
     private const double DegreePerLine = 0.9375;
     private const double DegreePerColor = 0.15625;
     private const double DegreePerTone = DegreePerColor / 6;
@@ -57,14 +57,18 @@ public static class HumanDesignUtility
     {
         var x = longitude - HdOffsetToZodiac;
         if (x < 0) x += 360;
-            
+						
         return new Activation()
         {
             Gate = (Gates)Math.Floor(x / DegreePerGate),
             Line = (Lines)Math.Floor((x % DegreePerGate) / DegreePerLine) + 1,
             Color = (Color)Math.Floor((x % DegreePerLine) / DegreePerColor) + 1,
             Tone = (Tone)Math.Floor((x % DegreePerColor) / DegreePerTone) + 1,
-            Base = (Base)Math.Floor((x % DegreePerTone) / DegreePerBase) + 1
+            Base = (Base)Math.Floor((x % DegreePerTone) / DegreePerBase) + 1,
+						Longitude = longitude,
+						ColorPercentage = (((x % DegreePerLine) % DegreePerColor) / DegreePerColor) * 100.0,
+						TonePercentage = (((x % DegreePerColor) % DegreePerTone) / DegreePerTone) * 100.0,
+						BasePercentage = (((x % DegreePerTone) % DegreePerBase) / DegreePerBase) * 100.0,
         };
     }
     


### PR DESCRIPTION
Can you review the percentage calculation for the planet activation?

Now we can log the activations like this:
```C#
Console.WriteLine("\nPersonality Gate Activations:");
foreach (var (planet, activation) in chart.PersonalityActivation)
{
    Console.WriteLine($"\t{planet} {activation}");
}

Console.WriteLine("\nDesign Gate Activations:");
foreach (var (planet, activation) in chart.DesignActivation)
{
    Console.WriteLine($"\t{planet} {activation}");
}
```
```LOG
Personality Gate Activations:
        Sun 64.1.3.2.3 C26% T56% B82%
        Earth 63.1.3.2.3 C26% T56% B82%
        NorthNode 63.3.6.3.4 C45% T71% B53%
        SouthNode 64.3.6.3.4 C45% T71% B53%
        Moon 45.6.5.4.4 C61% T66% B31%
        Mercury 18.3.1.5.4 C77% T63% B17%
        Uranus 11.5.5.2.4 C29% T72% B60%
        Venus 56.1.1.2.1 C19% T16% B81%
        Mars 21.2.4.3.1 C36% T15% B73%
        Neptune 58.4.6.1.2 C6% T38% B91%
        Saturn 11.4.4.2.3 C26% T55% B76%
        Jupiter 20.6.5.1.1 C1% T6% B31%
        Pluto 44.3.6.3.3 C42% T52% B61%

Design Gate Activations:
        Sun 35.3.4.1.2 C6% T36% B82%
        Earth 5.3.4.1.2 C6% T36% B82%
        NorthNode 22.3.1.2.5 C31% T86% B29%
        SouthNode 47.3.1.2.5 C31% T86% B29%
        Moon 41.1.2.5.1 C68% T8% B40%
        Mercury 12.5.1.2.2 C22% T30% B49%
        Uranus 10.2.4.2.4 C27% T61% B4%
        Venus 12.6.1.1.1 C1% T5% B25%
        Mars 37.3.3.5.4 C77% T61% B6%
        Neptune 58.6.6.6.4 C95% T69% B45%
        Saturn 10.3.2.6.4 C95% T69% B45%
        Jupiter 23.2.3.5.2 C72% T31% B57%
        Pluto 44.3.6.2.1 C19% T11% B57%
```
