### PR TITLE
WIP: Add TransitRange extension for gate/line boundary crossings

### DIFF
--- a/DataModels/TransitRangeEntry.cs
+++ b/DataModels/TransitRangeEntry.cs
@@ -1,0 +1,17 @@
+using SharpAstrology.Enums;
+
+namespace SharpAstrology.DataModels;
+
+/// <summary>
+/// A single gate/line transition entry in a transit range.
+/// The first entry for each planet describes the state at the range start;
+/// every subsequent entry marks the UTC instant the planet crosses into a new line.
+/// </summary>
+public sealed record TransitRangeEntry
+{
+    public required Planets Planet { get; init; }
+    public required Gates Gate { get; init; }
+    public required Lines Line { get; init; }
+    public int Retrograde { get; init; }
+    public required DateTime DateTime { get; init; }
+}

--- a/ExtensionMethods/HumanDesignIEphemeridesContextExtensionMethods.cs
+++ b/ExtensionMethods/HumanDesignIEphemeridesContextExtensionMethods.cs
@@ -1,3 +1,5 @@
+using SharpAstrology.DataModels;
+using SharpAstrology.Definitions;
 using SharpAstrology.Enums;
 using SharpAstrology.Interfaces;
 using SharpAstrology.HumanDesign.Mathematics;
@@ -29,5 +31,116 @@ public static class HumanDesignIEphemeridesContextExtensionMethods
         ), dateOfBirthJulian - 110, dateOfBirthJulian - 70, maxIterations: 1000);
         
         return AstrologyUtility.DateTimeFromJulianDate(dateOfIncomingJulian);
+    }
+
+    private static readonly Dictionary<Planets, TimeSpan> _transitStepByPlanet = new()
+    {
+        { Planets.Moon,      TimeSpan.FromMinutes(30) },
+        { Planets.Mercury,   TimeSpan.FromHours(4) },
+        { Planets.Venus,     TimeSpan.FromHours(8) },
+        { Planets.Sun,       TimeSpan.FromHours(8) },
+        { Planets.Earth,     TimeSpan.FromHours(8) },
+        { Planets.Mars,      TimeSpan.FromHours(8) },
+        { Planets.Jupiter,   TimeSpan.FromDays(1) },
+        { Planets.Saturn,    TimeSpan.FromDays(1) },
+        { Planets.Uranus,    TimeSpan.FromDays(1) },
+        { Planets.Neptune,   TimeSpan.FromDays(1) },
+        { Planets.Pluto,     TimeSpan.FromDays(1) },
+        { Planets.NorthNode, TimeSpan.FromDays(1) },
+        { Planets.SouthNode, TimeSpan.FromDays(1) },
+    };
+
+    /// <summary>
+    /// Computes the gate/line transit range for each Human Design planet across [start, end] (UTC).
+    /// Each planet's list begins with the state at <paramref name="start"/>;
+    /// every subsequent entry marks the exact UTC moment the planet enters a new line.
+    /// </summary>
+    public static Dictionary<Planets, List<TransitRangeEntry>> TransitRange(
+        this IEphemerides ephService,
+        DateTime start,
+        DateTime end,
+        EphCalculationMode mode = EphCalculationMode.Tropic)
+    {
+        if (start.Kind != DateTimeKind.Utc || end.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("start and end must be UTC");
+        if (end <= start)
+            throw new ArgumentException("end must be after start");
+
+        var result = new Dictionary<Planets, List<TransitRangeEntry>>();
+        foreach (var planet in HumanDesignDefaults.HumanDesignPlanets)
+        {
+            result[planet] = _transitRangeForPlanet(ephService, planet, start, end, mode);
+        }
+        return result;
+    }
+
+    private static List<TransitRangeEntry> _transitRangeForPlanet(
+        IEphemerides eph, Planets planet, DateTime start, DateTime end, EphCalculationMode mode)
+    {
+        var entries = new List<TransitRangeEntry>();
+        var step = _transitStepByPlanet.TryGetValue(planet, out var s) ? s : TimeSpan.FromHours(8);
+
+        var prevActivation = HumanDesignUtility.ActivationOf(eph.PlanetsPosition(planet, start, mode).Longitude);
+        entries.Add(new TransitRangeEntry
+        {
+            Planet = planet,
+            Gate = prevActivation.Gate,
+            Line = prevActivation.Line,
+            DateTime = start,
+        });
+
+        var prevTime = start;
+        var t = start + step;
+        while (prevTime < end)
+        {
+            if (t > end) t = end;
+            var currActivation = HumanDesignUtility.ActivationOf(eph.PlanetsPosition(planet, t, mode).Longitude);
+
+            if (currActivation.Gate != prevActivation.Gate || currActivation.Line != prevActivation.Line)
+            {
+                var (crossingTime, crossingActivation) = _findLineCrossing(eph, planet, mode, prevTime, t, prevActivation);
+                if (crossingTime <= end)
+                {
+                    entries.Add(new TransitRangeEntry
+                    {
+                        Planet = planet,
+                        Gate = crossingActivation.Gate,
+                        Line = crossingActivation.Line,
+                        DateTime = crossingTime,
+                    });
+                }
+                prevActivation = currActivation;
+                prevTime = t;
+                // If multiple line boundaries fell in this coarse interval, the next iteration
+                // from (prevTime=t) will continue detecting them; fast planets have small steps.
+            }
+            else
+            {
+                prevTime = t;
+            }
+
+            if (t >= end) break;
+            t += step;
+        }
+
+        return entries;
+    }
+
+    private static (DateTime, Activation) _findLineCrossing(
+        IEphemerides eph, Planets planet, EphCalculationMode mode,
+        DateTime lo, DateTime hi, Activation loActivation)
+    {
+        // Binary-search for the first instant inside (lo, hi] whose activation differs from loActivation.
+        while ((hi - lo).TotalSeconds > 1)
+        {
+            var mid = lo + TimeSpan.FromTicks((hi - lo).Ticks / 2);
+            var midActivation = HumanDesignUtility.ActivationOf(eph.PlanetsPosition(planet, mid, mode).Longitude);
+            if (midActivation.Gate == loActivation.Gate && midActivation.Line == loActivation.Line)
+                lo = mid;
+            else
+                hi = mid;
+        }
+        var hiActivation = HumanDesignUtility.ActivationOf(eph.PlanetsPosition(planet, hi, mode).Longitude);
+        return (hi, hiActivation);
     }
 }


### PR DESCRIPTION
Computes per-planet line-transition timelines over a UTC range. First entry per planet is the state at start; subsequent entries mark the exact instant the planet crosses into a new line.